### PR TITLE
femto cambios

### DIFF
--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -23,6 +23,7 @@ export const getPublicacionById = async (id: string) => {
 export const addPublicacion = async (formData: FormData) => {
     const res = await fetch("https://api-policlinico-production.up.railway.app/api/publicaciones", {
         method: "POST",
+        credentials: 'include',
         body: formData,
     })
 
@@ -36,6 +37,7 @@ export const addPublicacion = async (formData: FormData) => {
 export const deletePublicacion = async (id:number) => {
     const res = await fetch(`https://api-policlinico-production.up.railway.app/api/publicacionesdelete/${id}`, {
         method: "DELETE",
+        credentials: 'include',
     })
 
     if (!res.ok) {
@@ -49,6 +51,7 @@ export const deletePublicacion = async (id:number) => {
 export const updatePublicacion = async(formData:FormData, id:number) => {
     const res = await fetch(`https://api-policlinico-production.up.railway.app/api/publicacionesupdate/${id}`,{
         method: "POST",
+        credentials: 'include',
         body: formData
     })
     const data = await res.json()
@@ -80,6 +83,7 @@ export const getCarouselImageById = async (id: string) => {
 export const addCarouselImage = async (formData: FormData) => {
     const res = await fetch("https://api-policlinico-production.up.railway.app/api/carruselimagenes", {
         method: "POST",
+        credentials: 'include',
         body: formData,
     })
 
@@ -90,6 +94,7 @@ export const addCarouselImage = async (formData: FormData) => {
 export const deleteCarouselImage = async (id:number) => {
     const res = await fetch(`https://api-policlinico-production.up.railway.app/api/carruselimagenesdelete/${id}`, {
         method: "DELETE",
+        credentials: 'include',
     })
 
     if (!res.ok) {
@@ -103,6 +108,7 @@ export const deleteCarouselImage = async (id:number) => {
 export const updateCarouselImage = async(formData:FormData, id:number) => {
     const res = await fetch(`https://api-policlinico-production.up.railway.app/api/carruselimagenesupdate/${id}`,{
         method: "POST",
+        credentials: 'include',
         body: formData
     })
     const data = await res.json()


### PR DESCRIPTION
incluido ```credentials: 'include'``` en algunos fetches para que puedan dejar pasar la cookie de sesión.

Espero que este sistema funcione en producción.

Por cierto, ahora deberías de revisar si a tus fetches para modificar el carrusel y las publicaciones les llega un 401 (no autorizado), en ese caso podrías regresarlos a la página de login.